### PR TITLE
chore(deps): update checkout and validate maintenance commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l cmd internal)"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -count=1 ./...
+
+      - name: Build
+        run: go build ./...

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ check pull embedding/reranking models; model prewarming belongs in nix-openclaw.
 
 | Workflow | Schedule | What it does |
 |----------|----------|--------------|
+| **CI** | Pull requests and pushes to main | Checks Go formatting, vets, tests with the race detector, and builds the maintenance commands |
 | **sync-skills** | Every 30 min | Pulls latest skills from openclaw main |
 | **update-tools** | Every 10 min | Checks for new tool releases |
 | **Garnix** | On push | Builds all packages via `checks.*` (darwin + linux) |


### PR DESCRIPTION
## What Problem This Solves

The maintenance workflows still use checkout v4, and ordinary pull requests have no Go build/test workflow to validate changes to the updater and skill-sync commands.

## Why This Change Was Made

Upgrade both maintenance workflows to actions/checkout v7.0.1, pinned to its release commit. Add a read-only PR/main CI job that exercises the same checkout and checks Go formatting, vet, race tests, and builds. Keep scheduled automation permissions and behavior unchanged. Document the new gate in the README.

## User Impact

No packaged-tool or runtime behavior changes. All 12 packaged tools already match their latest upstream releases, and actions/create-github-app-token is already at v3.2.0. The Go module has no third-party requirements, and go mod tidy produces no changes. This repository has no changelog.

Held upgrades:

- Nixpkgs inputs/locks: retain revision 16c7794d0a28b5a37904d55bcca36003b9109aaa. The unstable branch has advanced, but this validation host has no Nix installation, so lock generation and package checks cannot be proven. No speculative hashes or partial lock updates.
- DeterminateSystems/nix-installer-action v12 to v22: hold because v22 defaults to Determinate Nix rather than the existing upstream Nix installation. Its documentation also limits upstream-Nix installation support to January 1, 2026. A distribution decision and Nix build proof are needed before changing this runtime boundary.

No open Dependabot/Renovate PRs are superseded.

## Evidence

Baseline default branch: main at 368848e. Latest six scheduled runs are green (three per workflow): [update-tools](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33143501623), [sync-skills](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33142737164). Latest [ClawSweeper Dispatch](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33108673100) and [CodeQL](https://github.com/openclaw/nix-openclaw-tools/actions/runs/32933095237) also succeeded. No Garnix check or commit status is attached to this default-branch commit; package-build health remains unverified.

Local proof on Go 1.27.0, macOS arm64:

- go test -race -count=1 -v ./...: 2 tests passed, 0 failed; 3 packages examined, 2 without tests.
- go vet ./..., go build ./..., and both command binary builds passed.
- Go formatting, actionlint 1.7.12 across all four workflows, and git diff --check passed.
- Built sync-skills smoke run in an isolated scratch directory exited 0 and copied 6 skills; 3 upstream skill paths are absent and skipped by existing behavior.
- Built update-tools smoke was blocked by the unauthenticated GitHub API quota (HTTP 403); release freshness was checked separately through authenticated gh.
- Codex autoreview completed with no actionable findings.

Limitations: nix flake check, package builds, and packaged CLI smoke tests could not run locally because Nix is not installed. The new CI job validates Go and checkout; it does not replace Garnix package builds.

PR verification: [CI](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33151539313) passed on the first attempt, including checkout, formatting, vet, race tests, build, and checkout cleanup. [CodeQL](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33151537021) and [ClawSweeper Dispatch](https://github.com/openclaw/nix-openclaw-tools/actions/runs/33151539309) also passed. No reruns or CI fixes were needed.
