### PR TITLE
fix(sync-skills): copy goplaces and the moved imsg path

### DIFF
--- a/cmd/sync-skills/main.go
+++ b/cmd/sync-skills/main.go
@@ -15,6 +15,49 @@ type Mapping struct {
 	Up   string
 }
 
+var skillMappings = []Mapping{
+	{"summarize", "skills/summarize"},
+	{"discrawl", "skills/discrawl"},
+	{"wacrawl", "skills/wacrawl"},
+	{"gogcli", "skills/gog"},
+	{"goplaces", "skills/goplaces"},
+	{"camsnap", "skills/camsnap"},
+	{"sonoscli", "skills/sonoscli"},
+	{"peekaboo", "skills/peekaboo"},
+	{"sag", "skills/sag"},
+	{"imsg", "extensions/imessage/skills/imsg"},
+}
+
+func destSkillPath(repoRoot string, m Mapping) string {
+	return filepath.Join(repoRoot, "tools", m.Tool, "skills", filepath.Base(m.Up), "SKILL.md")
+}
+
+func syncFrom(srcRoot, repoRoot string, mappings []Mapping) (bool, error) {
+	updated := false
+	for _, m := range mappings {
+		src := filepath.Join(srcRoot, m.Up, "SKILL.md")
+		dest := destSkillPath(repoRoot, m)
+		if _, err := os.Stat(src); err != nil {
+			log.Printf("[sync-skills] missing %s", src)
+			continue
+		}
+		same := false
+		if b1, err1 := os.ReadFile(src); err1 == nil {
+			if b2, err2 := os.ReadFile(dest); err2 == nil && bytes.Equal(b1, b2) {
+				same = true
+			}
+		}
+		if !same {
+			if err := copyFile(src, dest); err != nil {
+				return updated, fmt.Errorf("copy %s -> %s: %v", src, dest, err)
+			}
+			updated = true
+			log.Printf("[sync-skills] updated %s", m.Tool)
+		}
+	}
+	return updated, nil
+}
+
 func run(dir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
@@ -58,24 +101,12 @@ func main() {
 	}
 	defer os.RemoveAll(workdir)
 
-	mappings := []Mapping{
-		{"summarize", "skills/summarize"},
-		{"discrawl", "skills/discrawl"},
-		{"wacrawl", "skills/wacrawl"},
-		{"gogcli", "skills/gog"},
-		{"camsnap", "skills/camsnap"},
-		{"sonoscli", "skills/sonoscli"},
-		{"peekaboo", "skills/peekaboo"},
-		{"sag", "skills/sag"},
-		{"imsg", "skills/imsg"},
-	}
-
 	log.Printf("[sync-skills] cloning openclaw main")
 	if err := run("", "git", "clone", "--depth", "1", "--filter=blob:none", "--sparse", "https://github.com/openclaw/openclaw.git", workdir); err != nil {
 		log.Fatal(err)
 	}
 	paths := []string{}
-	for _, m := range mappings {
+	for _, m := range skillMappings {
 		paths = append(paths, m.Up)
 	}
 	args := append([]string{"sparse-checkout", "set"}, paths...)
@@ -83,29 +114,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	updated := false
-	for _, m := range mappings {
-		src := filepath.Join(workdir, m.Up, "SKILL.md")
-		dest := filepath.Join(repoRoot, "tools", m.Tool, "skills", filepath.Base(m.Up), "SKILL.md")
-		if _, err := os.Stat(src); err != nil {
-			log.Printf("[sync-skills] missing %s", src)
-			continue
-		}
-		same := false
-		if b1, err1 := os.ReadFile(src); err1 == nil {
-			if b2, err2 := os.ReadFile(dest); err2 == nil && bytes.Equal(b1, b2) {
-				same = true
-			}
-		}
-		if !same {
-			if err := copyFile(src, dest); err != nil {
-				log.Fatalf("copy %s -> %s: %v", src, dest, err)
-			}
-			updated = true
-			log.Printf("[sync-skills] updated %s", m.Tool)
-		}
+	updated, err := syncFrom(workdir, repoRoot, skillMappings)
+	if err != nil {
+		log.Fatal(err)
 	}
-
 	if !updated {
 		log.Printf("[sync-skills] no changes")
 	}

--- a/cmd/sync-skills/main_test.go
+++ b/cmd/sync-skills/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSkill(t *testing.T, root, rel, body string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readSkill(t *testing.T, root, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func mappingByTool(tool string) (Mapping, bool) {
+	for _, m := range skillMappings {
+		if m.Tool == tool {
+			return m, true
+		}
+	}
+	return Mapping{}, false
+}
+
+func TestSkillMappingsIncludeGoplacesAndMovedImsg(t *testing.T) {
+	goplaces, ok := mappingByTool("goplaces")
+	if !ok {
+		t.Fatal("skillMappings missing goplaces")
+	}
+	if goplaces.Up != "skills/goplaces" {
+		t.Fatalf("goplaces.Up = %q", goplaces.Up)
+	}
+
+	imsg, ok := mappingByTool("imsg")
+	if !ok {
+		t.Fatal("skillMappings missing imsg")
+	}
+	if imsg.Up != "extensions/imessage/skills/imsg" {
+		t.Fatalf("imsg.Up = %q, want extensions/imessage/skills/imsg", imsg.Up)
+	}
+	wantDest := filepath.Join("/repo", "tools", "imsg", "skills", "imsg", "SKILL.md")
+	if dest := destSkillPath("/repo", imsg); dest != wantDest {
+		t.Fatalf("imsg dest = %q, want %q", dest, wantDest)
+	}
+}
+
+func TestSyncFromCopiesGoplacesAndMovedImsg(t *testing.T) {
+	src := t.TempDir()
+	repo := t.TempDir()
+	writeSkill(t, src, "skills/goplaces/SKILL.md", "goplaces-upstream")
+	writeSkill(t, src, "extensions/imessage/skills/imsg/SKILL.md", "imsg-upstream")
+	writeSkill(t, repo, "tools/goplaces/skills/goplaces/SKILL.md", "stale-goplaces")
+	writeSkill(t, repo, "tools/imsg/skills/imsg/SKILL.md", "stale-imsg")
+
+	updated, err := syncFrom(src, repo, skillMappings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("expected updates")
+	}
+	if got := readSkill(t, repo, "tools/goplaces/skills/goplaces/SKILL.md"); got != "goplaces-upstream" {
+		t.Fatalf("goplaces dest = %q", got)
+	}
+	if got := readSkill(t, repo, "tools/imsg/skills/imsg/SKILL.md"); got != "imsg-upstream" {
+		t.Fatalf("imsg dest = %q", got)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `go run ./cmd/sync-skills` (or the 30-minute `sync-skills` workflow) would leave the packaged goplaces skill stale and never refresh imsg after OpenClaw moved that skill.

The hardcoded copy list never included `goplaces`, even though this repo already ships `tools/goplaces`. It still looked for `skills/imsg` after OpenClaw moved the file to `extensions/imessage/skills/imsg`. The job then logged `missing` for imsg and printed `no changes`, so the packaged skills drifted from OpenClaw main.

## Why This Change Was Made

Add `goplaces` -> `skills/goplaces` and point `imsg` at `extensions/imessage/skills/imsg`. The destination path is still `tools/<tool>/skills/<basename>/SKILL.md`, so imsg continues to land at `tools/imsg/skills/imsg/SKILL.md`.

The copy loop is the same skip-if-missing, overwrite-if-different behavior as before. Other tools are unchanged.

## User Impact

The next sync-skills run copies the current OpenClaw goplaces and imsg `SKILL.md` files into this repo. Packaged plugins stop shipping a never-updated goplaces skill and a frozen imsg skill.

## Evidence

OpenClaw main still has the goplaces skill and the moved imsg skill. The old imsg path is gone:

```console
$ gh api repos/openclaw/openclaw/contents/skills/goplaces/SKILL.md --jq '{path,size}'
{"path":"skills/goplaces/SKILL.md","size":1473}

$ gh api repos/openclaw/openclaw/contents/extensions/imessage/skills/imsg/SKILL.md --jq '{path,size}'
{"path":"extensions/imessage/skills/imsg/SKILL.md","size":10851}

$ gh api repos/openclaw/openclaw/contents/skills/imsg --jq '{message,status}'
{"message":"Not Found","status":"404"}
```

Local packaged copies have already drifted (3193-byte goplaces, 10091-byte imsg) because sync-skills never wrote those upstream files.

Compiled `sync-skills` from `upstream/main` against a fixture clone that contains both current OpenClaw paths. Destination files stayed stale:

```console
$ PATH="$PROOF/fakegit:$PATH" ./sync-skills-old
[sync-skills] cloning openclaw main
[sync-skills] missing .../skills/imsg/SKILL.md
[sync-skills] no changes

$ cat tools/goplaces/skills/goplaces/SKILL.md
stale-goplaces
$ cat tools/imsg/skills/imsg/SKILL.md
stale-imsg
```

Same fixture after this patch. The compiled binary copies both files:

```console
$ PATH="$PROOF/fakegit:$PATH" ./sync-skills
[sync-skills] cloning openclaw main
[sync-skills] updated goplaces
[sync-skills] updated imsg

$ cat tools/goplaces/skills/goplaces/SKILL.md
goplaces-upstream-body
$ cat tools/imsg/skills/imsg/SKILL.md
imsg-from-extensions
```

## Real behavior proof

- **Behavior or issue addressed:** sync-skills never copied goplaces and still read the removed `skills/imsg` path, so the packaged skills did not track OpenClaw main.
- **Real environment tested:** macOS 26.6.2, Darwin 25.6.0 arm64, Go 1.27.0. Compiled `./cmd/sync-skills` and the `upstream/main` binary. Fixture clone served by a PATH `git` wrapper that copies a tree with `skills/goplaces/SKILL.md` and `extensions/imessage/skills/imsg/SKILL.md`.
- **Exact steps or command run after this patch:**

  ```bash
  go build -o /tmp/nix-openclaw-tools-F002-live/sync-skills ./cmd/sync-skills
  cd /tmp/nix-openclaw-tools-F002-live/repo
  PATH=/tmp/nix-openclaw-tools-F002-live/fakegit:$PATH /tmp/nix-openclaw-tools-F002-live/sync-skills
  cat tools/goplaces/skills/goplaces/SKILL.md
  cat tools/imsg/skills/imsg/SKILL.md
  gh api repos/openclaw/openclaw/contents/skills/goplaces/SKILL.md --jq '{path,size}'
  gh api repos/openclaw/openclaw/contents/extensions/imessage/skills/imsg/SKILL.md --jq '{path,size}'
  ```

- **Evidence after fix:** terminal output from the patched binary:

  ```console
  $ PATH=/tmp/nix-openclaw-tools-F002-live/fakegit:$PATH /tmp/nix-openclaw-tools-F002-live/sync-skills
  [sync-skills] cloning openclaw main
  [sync-skills] updated goplaces
  [sync-skills] updated imsg
  $ cat tools/goplaces/skills/goplaces/SKILL.md
  goplaces-upstream-body
  $ cat tools/imsg/skills/imsg/SKILL.md
  imsg-from-extensions
  $ gh api repos/openclaw/openclaw/contents/skills/goplaces/SKILL.md --jq '{path,size}'
  {"path":"skills/goplaces/SKILL.md","size":1473}
  $ gh api repos/openclaw/openclaw/contents/extensions/imessage/skills/imsg/SKILL.md --jq '{path,size}'
  {"path":"extensions/imessage/skills/imsg/SKILL.md","size":10851}
  ```

- **Observed result after fix:** The patched `sync-skills` binary writes goplaces from `skills/goplaces` and imsg from `extensions/imessage/skills/imsg`. The unfixed binary from `upstream/main` logs `missing .../skills/imsg/SKILL.md`, prints `no changes`, and leaves both destination files stale.
- **What was not tested:** The GitHub Actions cron clone of live `openclaw/openclaw` (that would rewrite in-tree `SKILL.md` files in this branch). Garnix package builds.

## Related

Mapping table added in `2f25234` (2026-01-04, Josh Palmer). goplaces later landed as a packaged tool without a mapping. No open issue or competing PR for these paths. Sibling HTTP hang fix remains #17.
