### PR TITLE
fix: bound nix build summarize with a deadline

### DIFF
--- a/internal/nix.go
+++ b/internal/nix.go
@@ -2,12 +2,19 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
+
+// Linux source builds of summarize can exceed 10m.
+var summarizeTimeout = 45 * time.Minute
+
+var summarizeNix = "nix"
 
 type PrefetchResult struct {
 	Hash string `json:"hash"`
@@ -66,15 +73,21 @@ func NixBuildSummarize() (string, error) {
 }
 
 func NixBuildSummarizeSystem(system string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), summarizeTimeout)
+	defer cancel()
 	args := []string{"build", ".#summarize"}
 	if system != "" {
 		args = append(args, "--system", system)
 	}
-	cmd := exec.Command("nix", args...)
+	cmd := exec.CommandContext(ctx, summarizeNix, args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
+	isolateProcessGroup(cmd)
 	err := cmd.Run()
+	if err != nil && ctx.Err() != nil {
+		return out.String(), fmt.Errorf("nix build summarize: %w", ctx.Err())
+	}
 	return out.String(), err
 }
 

--- a/internal/nix_test.go
+++ b/internal/nix_test.go
@@ -1,0 +1,124 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	switch os.Getenv("OPENCLAW_FAKE_NIX") {
+	case "sleep":
+		time.Sleep(time.Hour)
+		os.Exit(0)
+	case "ok":
+		fmt.Fprintln(os.Stderr, `got:    sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`)
+		os.Exit(0)
+	}
+	if os.Getenv("OPENCLAW_SUMMARIZE_DEADLINE_DEMO") == "1" {
+		os.Exit(runSummarizeDeadlineDemo())
+	}
+	os.Exit(m.Run())
+}
+
+func runSummarizeDeadlineDemo() int {
+	summarizeTimeout = 200 * time.Millisecond
+	summarizeNix = os.Args[0]
+	if err := os.Setenv("OPENCLAW_FAKE_NIX", "sleep"); err != nil {
+		fmt.Fprintf(os.Stderr, "setenv: %v\n", err)
+		return 1
+	}
+	start := time.Now()
+	out, err := NixBuildSummarizeSystem("x86_64-linux")
+	elapsed := time.Since(start)
+	fmt.Fprintf(os.Stderr, "elapsed=%s err=%v\n", elapsed.Round(time.Millisecond), err)
+	if out != "" {
+		fmt.Fprintf(os.Stderr, "output=%q\n", out)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		fmt.Fprintln(os.Stderr, "deadline-abort=yes")
+		return 0
+	}
+	fmt.Fprintln(os.Stderr, "deadline-abort=no")
+	return 1
+}
+
+func TestNixBuildSummarizeSystemHonorsDeadline(t *testing.T) {
+	oldTimeout := summarizeTimeout
+	oldNix := summarizeNix
+	summarizeTimeout = 200 * time.Millisecond
+	summarizeNix = os.Args[0]
+	t.Setenv("OPENCLAW_FAKE_NIX", "sleep")
+	t.Cleanup(func() {
+		summarizeTimeout = oldTimeout
+		summarizeNix = oldNix
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NixBuildSummarizeSystem("x86_64-linux")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected deadline error, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NixBuildSummarizeSystem ignored the deadline and is still running")
+	}
+}
+
+func TestNixBuildSummarizeHonorsDeadline(t *testing.T) {
+	oldTimeout := summarizeTimeout
+	oldNix := summarizeNix
+	summarizeTimeout = 200 * time.Millisecond
+	summarizeNix = os.Args[0]
+	t.Setenv("OPENCLAW_FAKE_NIX", "sleep")
+	t.Cleanup(func() {
+		summarizeTimeout = oldTimeout
+		summarizeNix = oldNix
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NixBuildSummarize()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected deadline error, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NixBuildSummarize ignored the deadline and is still running")
+	}
+}
+
+func TestNixBuildSummarizeSystemReturnsOutput(t *testing.T) {
+	oldNix := summarizeNix
+	summarizeNix = os.Args[0]
+	t.Setenv("OPENCLAW_FAKE_NIX", "ok")
+	t.Cleanup(func() {
+		summarizeNix = oldNix
+	})
+
+	out, err := NixBuildSummarizeSystem("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := ExtractGotHash(out); got != "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" {
+		t.Fatalf("got hash %q from output %q", got, out)
+	}
+}

--- a/internal/nix_unix.go
+++ b/internal/nix_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package internal
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func isolateProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
+}

--- a/internal/nix_windows.go
+++ b/internal/nix_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package internal
+
+import "os/exec"
+
+func isolateProcessGroup(*exec.Cmd) {}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `update-tools` would hang forever when `nix build .#summarize` stalled on a Nix daemon or substituter. The scheduled `update-tools` workflow has no `timeout-minutes`, so GitHub's default 6 hour job limit was the only stop.

## Why This Change Was Made

`NixBuildSummarize` and `NixBuildSummarizeSystem` called `exec.Command("nix", ...).Run()` with no deadline. HTTP bounds in #17 and prefetch/clone bounds in #21 do not cover this `nix build`. Inner `timeout` in `summarize.nix` only wraps pnpm and tsc, not the Go-wrapped build.

This bounds the summarize build at 45 minutes via `CommandContext`. That is longer than 10 minutes because a Linux source build can exceed that. On Unix the helper also kills the process group so builder children do not stay behind after the deadline.

Prefetch, GitHub prefetch, and sync-skills clone are unchanged (those stay on #21).

## User Impact

A stalled summarize build now fails with `context deadline exceeded` instead of leaving the scheduled updater running until the job is cancelled.

## Evidence

terminal output from a live call to production `NixBuildSummarizeSystem` with a hanging `nix` child (the helper binary sleeps for an hour). Deadline set to 200ms.

Without `CommandContext`, the same call never returned. A 2s hang detector printed `NixBuildSummarizeSystem ignored the deadline and is still running` and the sleep child was still alive.

After the patch the compiled helper returns at 203ms:

```console
$ set OPENCLAW_SUMMARIZE_DEADLINE_DEMO=1
$ %TEMP%\summarize-deadline-demo.exe
elapsed=203ms err=nix build summarize: context deadline exceeded
deadline-abort=yes
```

The child is gone after return. A fast succeeding fake `nix` still returns its stdout hash line.

## Real behavior proof

- **Behavior or issue addressed:** `go run ./cmd/update-tools` could block forever on `nix build .#summarize` (and the darwin fallback `--system x86_64-linux`). Workflow `update-tools.yml` has no job timeout.
- **Real environment tested:** Windows 10 amd64, go1.27.0, worktree `C:\Users\sebta\.grok\tmp\pr-gate-batch\nix-openclaw-tools-f004` on `fix/nix-build-summarize-timeout`.
- **Exact steps or command run after this patch:** Built `%TEMP%\summarize-deadline-demo.exe` from `./internal/`, set `OPENCLAW_SUMMARIZE_DEADLINE_DEMO=1`, and ran that binary so it calls `NixBuildSummarizeSystem("x86_64-linux")` against a sleeping `nix` child with a 200ms deadline.
- **Evidence after fix:** terminal output above. Return at 203ms, `nix build summarize: context deadline exceeded`, `deadline-abort=yes`.
- **Observed result after fix:** Production `NixBuildSummarizeSystem` returns a deadline error and the hung child is killed. `NixBuildSummarize` uses the same path. Default deadline is 45 minutes.
- **What was not tested:** A full `go run ./cmd/update-tools` against a live Nix daemon and GitHub (would rewrite package hashes). Prefetch and clone paths are not changed here.

## Related

- Prefetch and clone deadlines: [#21](https://github.com/openclaw/nix-openclaw-tools/pull/21)
- HTTP-only hang bound: [#17](https://github.com/openclaw/nix-openclaw-tools/pull/17)
- Child process deadline: [exec.CommandContext](https://pkg.go.dev/os/exec#CommandContext)
